### PR TITLE
Fixed typo in CMake Boost header resolution.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(SPEAR_BUILD_SHADER_FACTORY)
 
     if(NOT Boost_FOUND) # Assume directory is in libs/boost.
         message("Using custom Boost libraries at libs/boost!")
-		set(Boost_INCLUDE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/libs/boost CACHE PATH "boost location")
+        set(Boost_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/libs/boost CACHE PATH "Location of the Boost libraries.")
 		set(Boost_FOUND ON)
     endif()
 


### PR DESCRIPTION
I cloned SPEAR on a fresh installation and the CMake file didn't like me having a local installation of Boost. i.e. the `find_package` approach works, but when `Boost_FOUND` is false it fails. I've fixed the issue, it was a typo: `Boost_INCLUDE_DIR` should be `Boost_INCLUDE_DIRS` when setting the cached path. Everything else seems to work fine though :-)